### PR TITLE
Add Oracle datasource support

### DIFF
--- a/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceProperties.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceProperties.java
@@ -37,9 +37,13 @@ import static com.alibaba.nacos.common.utils.CollectionUtils.getOrDefault;
  */
 public class ExternalDataSourceProperties {
     
-    private static final String JDBC_DRIVER_NAME = "com.mysql.cj.jdbc.Driver";
-    
-    private static final String TEST_QUERY = "SELECT 1";
+    private static final String MYSQL_DRIVER = "com.mysql.cj.jdbc.Driver";
+
+    private static final String ORACLE_DRIVER = "oracle.jdbc.OracleDriver";
+
+    private static final String MYSQL_TEST_QUERY = "SELECT 1";
+
+    private static final String ORACLE_TEST_QUERY = "SELECT 1 FROM DUAL";
     
     private Integer num;
     
@@ -82,15 +86,24 @@ public class ExternalDataSourceProperties {
             int currentSize = index + 1;
             Preconditions.checkArgument(url.size() >= currentSize, "db.url.%s is null", index);
             DataSourcePoolProperties poolProperties = DataSourcePoolProperties.build(environment);
+            String jdbcUrl = url.get(index).trim();
             if (StringUtils.isEmpty(poolProperties.getDataSource().getDriverClassName())) {
-                poolProperties.setDriverClassName(JDBC_DRIVER_NAME);
+                if (jdbcUrl.startsWith("jdbc:oracle")) {
+                    poolProperties.setDriverClassName(ORACLE_DRIVER);
+                } else {
+                    poolProperties.setDriverClassName(MYSQL_DRIVER);
+                }
             }
-            poolProperties.setJdbcUrl(url.get(index).trim());
+            poolProperties.setJdbcUrl(jdbcUrl);
             poolProperties.setUsername(getOrDefault(user, index, user.get(0)).trim());
             poolProperties.setPassword(getOrDefault(password, index, password.get(0)).trim());
             HikariDataSource ds = poolProperties.getDataSource();
             if (StringUtils.isEmpty(ds.getConnectionTestQuery())) {
-                ds.setConnectionTestQuery(TEST_QUERY);
+                if (jdbcUrl.startsWith("jdbc:oracle")) {
+                    ds.setConnectionTestQuery(ORACLE_TEST_QUERY);
+                } else {
+                    ds.setConnectionTestQuery(MYSQL_TEST_QUERY);
+                }
             }
             
             dataSources.add(ds);

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/DataSourceConstant.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/DataSourceConstant.java
@@ -24,6 +24,11 @@ package com.alibaba.nacos.plugin.datasource.constants;
 
 public class DataSourceConstant {
     public static final String MYSQL = "mysql";
-    
+
     public static final String DERBY = "derby";
+
+    /**
+     * Oracle database type constant.
+     */
+    public static final String ORACLE = "oracle";
 }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/enums/oracle/TrustedOracleFunctionEnum.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/enums/oracle/TrustedOracleFunctionEnum.java
@@ -1,0 +1,46 @@
+package com.alibaba.nacos.plugin.datasource.enums.oracle;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Trusted oracle functions enumeration.
+ */
+public enum TrustedOracleFunctionEnum {
+
+    /**
+     * Current timestamp.
+     */
+    NOW("NOW()", "SYSTIMESTAMP");
+
+    private static final Map<String, TrustedOracleFunctionEnum> LOOKUP_MAP = new HashMap<>();
+
+    static {
+        for (TrustedOracleFunctionEnum entry : TrustedOracleFunctionEnum.values()) {
+            LOOKUP_MAP.put(entry.functionName, entry);
+        }
+    }
+
+    private final String functionName;
+
+    private final String function;
+
+    TrustedOracleFunctionEnum(String functionName, String function) {
+        this.functionName = functionName;
+        this.function = function;
+    }
+
+    /**
+     * Get the real sql function by name.
+     *
+     * @param functionName function name
+     * @return real function
+     */
+    public static String getFunctionByName(String functionName) {
+        TrustedOracleFunctionEnum entry = LOOKUP_MAP.get(functionName);
+        if (entry != null) {
+            return entry.function;
+        }
+        throw new IllegalArgumentException("Invalid function name: " + functionName);
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/AbstractMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/AbstractMapperByOracle.java
@@ -1,0 +1,15 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.plugin.datasource.enums.oracle.TrustedOracleFunctionEnum;
+import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
+
+/**
+ * Abstract mapper for Oracle database.
+ */
+public abstract class AbstractMapperByOracle extends AbstractMapper {
+
+    @Override
+    public String getFunction(String functionName) {
+        return TrustedOracleFunctionEnum.getFunctionByName(functionName);
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoBetaMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoBetaMapperByOracle.java
@@ -1,0 +1,33 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoBetaMapper;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Oracle implementation of ConfigInfoBetaMapper.
+ */
+public class ConfigInfoBetaMapperByOracle extends AbstractMapperByOracle implements ConfigInfoBetaMapper {
+
+    @Override
+    public MapperResult findAllConfigInfoBetaForDumpAllFetchRows(MapperContext context) {
+        int startRow = context.getStartRow();
+        int pageSize = context.getPageSize();
+        String sql = " SELECT t.id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,beta_ips,encrypted_data_key "
+                + " FROM ( SELECT id FROM config_info_beta  ORDER BY id OFFSET " + startRow
+                + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY )" + "  g, config_info_beta t WHERE g.id = t.id ";
+        List<Object> paramList = new ArrayList<>();
+        paramList.add(startRow);
+        paramList.add(pageSize);
+        return new MapperResult(sql, paramList);
+    }
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoGrayMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoGrayMapperByOracle.java
@@ -1,0 +1,27 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoGrayMapper;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+import java.util.Collections;
+
+/**
+ * Oracle implementation of ConfigInfoGrayMapper.
+ */
+public class ConfigInfoGrayMapperByOracle extends AbstractMapperByOracle implements ConfigInfoGrayMapper {
+
+    @Override
+    public MapperResult findAllConfigInfoGrayForDumpAllFetchRows(MapperContext context) {
+        String sql = " SELECT id,data_id,group_id,tenant_id,gray_name,gray_rule,app_name,content,md5,gmt_modified "
+                + " FROM  config_info_gray  ORDER BY id OFFSET " + context.getStartRow()
+                + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
+        return new MapperResult(sql, Collections.emptyList());
+    }
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoMapperByOracle.java
@@ -1,0 +1,249 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.common.utils.ArrayUtils;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.NamespaceUtil;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.mapper.ext.WhereBuilder;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Oracle implementation of ConfigInfoMapper.
+ */
+public class ConfigInfoMapperByOracle extends AbstractMapperByOracle implements ConfigInfoMapper {
+
+    private static final String DATA_ID = "dataId";
+    private static final String GROUP = "group";
+    private static final String APP_NAME = "appName";
+    private static final String CONTENT = "content";
+    private static final String TENANT = "tenant";
+
+    @Override
+    public MapperResult findConfigInfoByAppFetchRows(MapperContext context) {
+        final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
+        final String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
+        String sql = "SELECT id,data_id,group_id,tenant_id,app_name,content FROM config_info"
+                + " WHERE tenant_id LIKE ? AND app_name= ? OFFSET " + context.getStartRow()
+                + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
+        return new MapperResult(sql, CollectionUtils.list(tenantId, appName));
+    }
+
+    @Override
+    public MapperResult getTenantIdList(MapperContext context) {
+        String sql = "SELECT tenant_id FROM config_info WHERE tenant_id != '" + NamespaceUtil.getNamespaceDefaultId()
+                + "' GROUP BY tenant_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
+        return new MapperResult(sql, Collections.emptyList());
+    }
+
+    @Override
+    public MapperResult getGroupIdList(MapperContext context) {
+        String sql = "SELECT group_id FROM config_info WHERE tenant_id ='" + NamespaceUtil.getNamespaceDefaultId()
+                + "' GROUP BY group_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
+        return new MapperResult(sql, Collections.emptyList());
+    }
+
+    @Override
+    public MapperResult findAllConfigKey(MapperContext context) {
+        String sql = " SELECT data_id,group_id,app_name  FROM ( "
+                + " SELECT id FROM config_info WHERE tenant_id LIKE ? ORDER BY id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
+                + context.getPageSize() + " ROWS ONLY )" + " g, config_info t WHERE g.id = t.id  ";
+        return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.TENANT_ID)));
+    }
+
+    @Override
+    public MapperResult findAllConfigInfoBaseFetchRows(MapperContext context) {
+        String sql = "SELECT t.id,data_id,group_id,content,md5" + " FROM ( SELECT id FROM config_info ORDER BY id OFFSET "
+                + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY )"
+                + " g, config_info t  WHERE g.id = t.id ";
+        return new MapperResult(sql, Collections.emptyList());
+    }
+
+    @Override
+    public MapperResult findAllConfigInfoFragment(MapperContext context) {
+        String contextParameter = context.getContextParameter(ContextConstant.NEED_CONTENT);
+        boolean needContent = contextParameter != null && Boolean.parseBoolean(contextParameter);
+        String sql = "SELECT id,data_id,group_id,tenant_id,app_name," + (needContent ? "content," : "")
+                + "md5,gmt_modified,type,encrypted_data_key FROM config_info WHERE id > ? ORDER BY id ASC OFFSET "
+                + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
+        return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.ID)));
+    }
+
+    @Override
+    public MapperResult findChangeConfigFetchRows(MapperContext context) {
+        final String tenant = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
+        final String dataId = (String) context.getWhereParameter(FieldConstant.DATA_ID);
+        final String group = (String) context.getWhereParameter(FieldConstant.GROUP_ID);
+        final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
+        final String tenantTmp = StringUtils.isBlank(tenant) ? StringUtils.EMPTY : tenant;
+        final Timestamp startTime = (Timestamp) context.getWhereParameter(FieldConstant.START_TIME);
+        final Timestamp endTime = (Timestamp) context.getWhereParameter(FieldConstant.END_TIME);
+
+        List<Object> paramList = new ArrayList<>();
+
+        final String sqlFetchRows = "SELECT id,data_id,group_id,tenant_id,app_name,type,md5,gmt_modified FROM config_info WHERE ";
+        String where = " 1=1 ";
+        if (!StringUtils.isBlank(dataId)) {
+            where += " AND data_id LIKE ? ";
+            paramList.add(dataId);
+        }
+        if (!StringUtils.isBlank(group)) {
+            where += " AND group_id LIKE ? ";
+            paramList.add(group);
+        }
+
+        if (!StringUtils.isBlank(tenantTmp)) {
+            where += " AND tenant_id = ? ";
+            paramList.add(tenantTmp);
+        }
+
+        if (!StringUtils.isBlank(appName)) {
+            where += " AND app_name = ? ";
+            paramList.add(appName);
+        }
+        if (startTime != null) {
+            where += " AND gmt_modified >=? ";
+            paramList.add(startTime);
+        }
+        if (endTime != null) {
+            where += " AND gmt_modified <=? ";
+            paramList.add(endTime);
+        }
+        return new MapperResult(
+                sqlFetchRows + where + " AND id > " + context.getWhereParameter(FieldConstant.LAST_MAX_ID)
+                        + " ORDER BY id ASC OFFSET 0 ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY", paramList);
+    }
+
+    @Override
+    public MapperResult listGroupKeyMd5ByPageFetchRows(MapperContext context) {
+        String sql = "SELECT t.id,data_id,group_id,tenant_id,app_name,md5,type,gmt_modified,encrypted_data_key FROM "
+                + "( SELECT id FROM config_info ORDER BY id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
+                + context.getPageSize() + " ROWS ONLY ) g, config_info t WHERE g.id = t.id";
+        return new MapperResult(sql, Collections.emptyList());
+    }
+
+    @Override
+    public MapperResult findConfigInfoBaseLikeFetchRows(MapperContext context) {
+        final String dataId = (String) context.getWhereParameter(FieldConstant.DATA_ID);
+        final String group = (String) context.getWhereParameter(FieldConstant.GROUP_ID);
+        final String content = (String) context.getWhereParameter(FieldConstant.CONTENT);
+
+        final String sqlFetchRows = "SELECT id,data_id,group_id,tenant_id,content FROM config_info WHERE ";
+        String where = " 1=1 AND tenant_id='" + NamespaceUtil.getNamespaceDefaultId() + "' ";
+
+        List<Object> paramList = new ArrayList<>();
+
+        if (!StringUtils.isBlank(dataId)) {
+            where += " AND data_id LIKE ? ";
+            paramList.add(dataId);
+        }
+        if (!StringUtils.isBlank(group)) {
+            where += " AND group_id LIKE ? ";
+            paramList.add(group);
+        }
+        if (!StringUtils.isBlank(content)) {
+            where += " AND content LIKE ? ";
+            paramList.add(content);
+        }
+        return new MapperResult(sqlFetchRows + where + " OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY",
+                paramList);
+    }
+
+    @Override
+    public MapperResult findConfigInfo4PageFetchRows(MapperContext context) {
+        final String tenant = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
+        final String dataId = (String) context.getWhereParameter(FieldConstant.DATA_ID);
+        final String group = (String) context.getWhereParameter(FieldConstant.GROUP_ID);
+        final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
+        final String content = (String) context.getWhereParameter(FieldConstant.CONTENT);
+
+        List<Object> paramList = new ArrayList<>();
+
+        final String sql = "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,type,encrypted_data_key FROM config_info";
+        StringBuilder where = new StringBuilder(" WHERE ");
+        where.append(" tenant_id=? ");
+        paramList.add(tenant);
+        if (StringUtils.isNotBlank(dataId)) {
+            where.append(" AND data_id=? ");
+            paramList.add(dataId);
+        }
+        if (StringUtils.isNotBlank(group)) {
+            where.append(" AND group_id=? ");
+            paramList.add(group);
+        }
+        if (StringUtils.isNotBlank(appName)) {
+            where.append(" AND app_name=? ");
+            paramList.add(appName);
+        }
+        if (!StringUtils.isBlank(content)) {
+            where.append(" AND content LIKE ? ");
+            paramList.add(content);
+        }
+        return new MapperResult(sql + where + " OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY",
+                paramList);
+    }
+
+    @Override
+    public MapperResult findConfigInfoBaseByGroupFetchRows(MapperContext context) {
+        String sql = "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? AND tenant_id=?" + " OFFSET "
+                + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
+        return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.GROUP_ID),
+                context.getWhereParameter(FieldConstant.TENANT_ID)));
+    }
+
+    @Override
+    public MapperResult findConfigInfoLike4PageFetchRows(MapperContext context) {
+        final String tenant = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
+        final String dataId = (String) context.getWhereParameter(FieldConstant.DATA_ID);
+        final String group = (String) context.getWhereParameter(FieldConstant.GROUP_ID);
+        final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
+        final String content = (String) context.getWhereParameter(FieldConstant.CONTENT);
+        final String[] types = (String[]) context.getWhereParameter(FieldConstant.TYPE);
+
+        WhereBuilder where = new WhereBuilder(
+                "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,encrypted_data_key,type FROM config_info");
+        where.like("tenant_id", tenant);
+
+        if (StringUtils.isNotBlank(dataId)) {
+            where.and().like("data_id", dataId);
+        }
+        if (StringUtils.isNotBlank(group)) {
+            where.and().like("group_id", group);
+        }
+        if (StringUtils.isNotBlank(appName)) {
+            where.and().eq("app_name", appName);
+        }
+        if (StringUtils.isNotBlank(content)) {
+            where.and().like("content", content);
+        }
+        if (!ArrayUtils.isEmpty(types)) {
+            where.and().in("type", types);
+        }
+        where.offset(context.getStartRow(), context.getPageSize());
+        return where.build();
+    }
+
+    @Override
+    public MapperResult findAllConfigInfoFetchRows(MapperContext context) {
+        String sql = "SELECT t.id,data_id,group_id,tenant_id,app_name,content,md5 "
+                + " FROM (  SELECT id FROM config_info WHERE tenant_id LIKE ? ORDER BY id OFFSET ? ROWS FETCH NEXT ? ROWS ONLY )"
+                + " g, config_info t  WHERE g.id = t.id ";
+        return new MapperResult(sql,
+                CollectionUtils.list(context.getWhereParameter(FieldConstant.TENANT_ID), context.getStartRow(),
+                        context.getPageSize()));
+    }
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoTagMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoTagMapperByOracle.java
@@ -1,0 +1,27 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoTagMapper;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+import java.util.Collections;
+
+/**
+ * Oracle implementation of ConfigInfoTagMapper.
+ */
+public class ConfigInfoTagMapperByOracle extends AbstractMapperByOracle implements ConfigInfoTagMapper {
+
+    @Override
+    public MapperResult findAllConfigInfoTagForDumpAllFetchRows(MapperContext context) {
+        String sql = " SELECT t.id,data_id,group_id,tenant_id,tag_id,app_name,content,md5,gmt_modified "
+                + " FROM (  SELECT id FROM config_info_tag  ORDER BY id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
+                + context.getPageSize() + " ROWS ONLY ) " + "g, config_info_tag t  WHERE g.id = t.id  ";
+        return new MapperResult(sql, Collections.emptyList());
+    }
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigMigrateMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigMigrateMapperByOracle.java
@@ -1,0 +1,15 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.ConfigMigrateMapper;
+
+/**
+ * Config migrate mapper for Oracle.
+ */
+public class ConfigMigrateMapperByOracle extends AbstractMapperByOracle implements ConfigMigrateMapper {
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigTagsRelationMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigTagsRelationMapperByOracle.java
@@ -1,0 +1,118 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.common.utils.ArrayUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.ConfigTagsRelationMapper;
+import com.alibaba.nacos.plugin.datasource.mapper.ext.WhereBuilder;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Oracle implementation of ConfigTagsRelationMapper.
+ */
+public class ConfigTagsRelationMapperByOracle extends AbstractMapperByOracle implements ConfigTagsRelationMapper {
+
+    @Override
+    public MapperResult findConfigInfo4PageFetchRows(MapperContext context) {
+        final String tenant = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
+        final String dataId = (String) context.getWhereParameter(FieldConstant.DATA_ID);
+        final String group = (String) context.getWhereParameter(FieldConstant.GROUP_ID);
+        final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
+        final String content = (String) context.getWhereParameter(FieldConstant.CONTENT);
+        final String[] tagArr = (String[]) context.getWhereParameter(FieldConstant.TAG_ARR);
+
+        List<Object> paramList = new ArrayList<>();
+        StringBuilder where = new StringBuilder(" WHERE ");
+        final String sql =
+                "SELECT a.id,a.data_id,a.group_id,a.tenant_id,a.app_name,a.content FROM config_info  a LEFT JOIN "
+                        + "config_tags_relation b ON a.id=b.id";
+
+        where.append(" a.tenant_id=? ");
+        paramList.add(tenant);
+
+        if (StringUtils.isNotBlank(dataId)) {
+            where.append(" AND a.data_id=? ");
+            paramList.add(dataId);
+        }
+        if (StringUtils.isNotBlank(group)) {
+            where.append(" AND a.group_id=? ");
+            paramList.add(group);
+        }
+        if (StringUtils.isNotBlank(appName)) {
+            where.append(" AND a.app_name=? ");
+            paramList.add(appName);
+        }
+        if (!StringUtils.isBlank(content)) {
+            where.append(" AND a.content LIKE ? ");
+            paramList.add(content);
+        }
+        where.append(" AND b.tag_name IN (");
+        for (int i = 0; i < tagArr.length; i++) {
+            if (i != 0) {
+                where.append(", ");
+            }
+            where.append('?');
+            paramList.add(tagArr[i]);
+        }
+        where.append(") ");
+        return new MapperResult(sql + where + " OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY",
+                paramList);
+    }
+
+    @Override
+    public MapperResult findConfigInfoLike4PageFetchRows(MapperContext context) {
+        final String tenant = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
+        final String dataId = (String) context.getWhereParameter(FieldConstant.DATA_ID);
+        final String group = (String) context.getWhereParameter(FieldConstant.GROUP_ID);
+        final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
+        final String content = (String) context.getWhereParameter(FieldConstant.CONTENT);
+        final String[] tagArr = (String[]) context.getWhereParameter(FieldConstant.TAG_ARR);
+        final String[] types = (String[]) context.getWhereParameter(FieldConstant.TYPE);
+
+        WhereBuilder where = new WhereBuilder(
+                "SELECT a.id,a.data_id,a.group_id,a.tenant_id,a.app_name,a.content,a.type "
+                        + "FROM config_info a LEFT JOIN config_tags_relation b ON a.id=b.id");
+
+        where.like("a.tenant_id", tenant);
+
+        if (StringUtils.isNotBlank(dataId)) {
+            where.and().like("a.data_id", dataId);
+        }
+        if (StringUtils.isNotBlank(group)) {
+            where.and().like("a.group_id", group);
+        }
+        if (StringUtils.isNotBlank(appName)) {
+            where.and().eq("a.app_name", appName);
+        }
+        if (StringUtils.isNotBlank(content)) {
+            where.and().like("a.content", content);
+        }
+        if (!ArrayUtils.isEmpty(tagArr)) {
+            where.and().startParentheses();
+            for (int i = 0; i < tagArr.length; i++) {
+                if (i != 0) {
+                    where.or();
+                }
+                where.like("b.tag_name", tagArr[i]);
+            }
+            where.endParentheses();
+        }
+        if (!ArrayUtils.isEmpty(types)) {
+            where.and().in("a.type", types);
+        }
+
+        where.offset(context.getStartRow(), context.getPageSize());
+
+        return where.build();
+    }
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/GroupCapacityMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/GroupCapacityMapperByOracle.java
@@ -1,0 +1,124 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.NamespaceUtil;
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.GroupCapacityMapper;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Oracle implementation of {@link GroupCapacityMapper}.
+ */
+public class GroupCapacityMapperByOracle extends AbstractMapperByOracle implements GroupCapacityMapper {
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+
+    @Override
+    public MapperResult selectGroupInfoBySize(MapperContext context) {
+        String sql = "SELECT id, group_id FROM group_capacity WHERE id > ? OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY";
+        return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.ID), context.getPageSize()));
+    }
+
+    @Override
+    public MapperResult select(MapperContext context) {
+        String sql = "SELECT id, quota, usage, max_size, max_aggr_count, max_aggr_size, group_id FROM group_capacity "
+                + "WHERE group_id = ?";
+        return new MapperResult(sql, Collections.singletonList(context.getWhereParameter(FieldConstant.GROUP_ID)));
+    }
+
+    @Override
+    public MapperResult insertIntoSelect(MapperContext context) {
+        List<Object> paramList = new ArrayList<>();
+        paramList.add(context.getUpdateParameter(FieldConstant.GROUP_ID));
+        paramList.add(context.getUpdateParameter(FieldConstant.QUOTA));
+        paramList.add(context.getUpdateParameter(FieldConstant.MAX_SIZE));
+        paramList.add(context.getUpdateParameter(FieldConstant.MAX_AGGR_COUNT));
+        paramList.add(context.getUpdateParameter(FieldConstant.MAX_AGGR_SIZE));
+        paramList.add(context.getUpdateParameter(FieldConstant.GMT_CREATE));
+        paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
+
+        String sql =
+                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size,gmt_create,"
+                        + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info";
+        return new MapperResult(sql, paramList);
+    }
+
+    @Override
+    public MapperResult insertIntoSelectByWhere(MapperContext context) {
+        final String sql =
+                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size, gmt_create,"
+                        + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE group_id=? AND tenant_id = '"
+                        + NamespaceUtil.getNamespaceDefaultId() + "'";
+        List<Object> paramList = new ArrayList<>();
+        paramList.add(context.getUpdateParameter(FieldConstant.GROUP_ID));
+        paramList.add(context.getUpdateParameter(FieldConstant.QUOTA));
+        paramList.add(context.getUpdateParameter(FieldConstant.MAX_SIZE));
+        paramList.add(context.getUpdateParameter(FieldConstant.MAX_AGGR_COUNT));
+        paramList.add(context.getUpdateParameter(FieldConstant.MAX_AGGR_SIZE));
+        paramList.add(context.getUpdateParameter(FieldConstant.GMT_CREATE));
+        paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
+
+        paramList.add(context.getWhereParameter(FieldConstant.GROUP_ID));
+
+        return new MapperResult(sql, paramList);
+    }
+
+    @Override
+    public MapperResult incrementUsageByWhereQuotaEqualZero(MapperContext context) {
+        return new MapperResult(
+                "UPDATE group_capacity SET usage = usage + 1, gmt_modified = ? WHERE group_id = ? AND usage < ? AND quota = 0",
+                CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.GROUP_ID),
+                        context.getWhereParameter(FieldConstant.USAGE)));
+    }
+
+    @Override
+    public MapperResult incrementUsageByWhereQuotaNotEqualZero(MapperContext context) {
+        return new MapperResult(
+                "UPDATE group_capacity SET usage = usage + 1, gmt_modified = ? WHERE group_id = ? AND usage < quota AND quota != 0",
+                CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.GROUP_ID)));
+    }
+
+    @Override
+    public MapperResult incrementUsageByWhere(MapperContext context) {
+        return new MapperResult("UPDATE group_capacity SET usage = usage + 1, gmt_modified = ? WHERE group_id = ?",
+                CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.GROUP_ID)));
+    }
+
+    @Override
+    public MapperResult decrementUsageByWhere(MapperContext context) {
+        return new MapperResult(
+                "UPDATE group_capacity SET usage = usage - 1, gmt_modified = ? WHERE group_id = ? AND usage > 0",
+                CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.GROUP_ID)));
+    }
+
+    @Override
+    public MapperResult updateUsage(MapperContext context) {
+        return new MapperResult(
+                "UPDATE group_capacity SET usage = (SELECT count(*) FROM config_info), gmt_modified = ? WHERE group_id = ?",
+                CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.GROUP_ID)));
+    }
+
+    @Override
+    public MapperResult updateUsageByWhere(MapperContext context) {
+        return new MapperResult(
+                "UPDATE group_capacity SET usage = (SELECT count(*) FROM config_info WHERE group_id=? AND tenant_id = '"
+                        + NamespaceUtil.getNamespaceDefaultId() + "')," + " gmt_modified = ? WHERE group_id= ?",
+                CollectionUtils.list(context.getWhereParameter(FieldConstant.GROUP_ID),
+                        context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.GROUP_ID)));
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/HistoryConfigInfoMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/HistoryConfigInfoMapperByOracle.java
@@ -1,0 +1,36 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.HistoryConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+/**
+ * Oracle implementation of HistoryConfigInfoMapper.
+ */
+public class HistoryConfigInfoMapperByOracle extends AbstractMapperByOracle implements HistoryConfigInfoMapper {
+
+    @Override
+    public MapperResult removeConfigHistory(MapperContext context) {
+        String sql = "DELETE FROM his_config_info WHERE gmt_modified < ? AND ROWNUM <= ?";
+        return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.START_TIME),
+                context.getWhereParameter(FieldConstant.LIMIT_SIZE)));
+    }
+
+    @Override
+    public MapperResult pageFindConfigHistoryFetchRows(MapperContext context) {
+        String sql =
+                "SELECT nid,data_id,group_id,tenant_id,app_name,src_ip,src_user,op_type,ext_info,publish_type,gray_name,gmt_create,gmt_modified "
+                        + "FROM his_config_info " + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? ORDER BY nid DESC OFFSET "
+                        + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
+        return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.DATA_ID),
+                context.getWhereParameter(FieldConstant.GROUP_ID), context.getWhereParameter(FieldConstant.TENANT_ID)));
+    }
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/TenantCapacityMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/TenantCapacityMapperByOracle.java
@@ -1,0 +1,97 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.TenantCapacityMapper;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Oracle implementation of TenantCapacityMapper.
+ */
+public class TenantCapacityMapperByOracle extends AbstractMapperByOracle implements TenantCapacityMapper {
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+
+    @Override
+    public MapperResult select(MapperContext context) {
+        String sql = "SELECT id, quota, usage, max_size, max_aggr_count, max_aggr_size, tenant_id FROM tenant_capacity "
+                + "WHERE tenant_id = ?";
+        return new MapperResult(sql, Collections.singletonList(context.getWhereParameter(FieldConstant.TENANT_ID)));
+    }
+
+    @Override
+    public MapperResult getCapacityList4CorrectUsage(MapperContext context) {
+        String sql = "SELECT id, tenant_id FROM tenant_capacity WHERE id>? OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY";
+        return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.ID),
+                context.getWhereParameter(FieldConstant.LIMIT_SIZE)));
+    }
+
+    @Override
+    public MapperResult incrementUsageWithDefaultQuotaLimit(MapperContext context) {
+        return new MapperResult(
+                "UPDATE tenant_capacity SET usage = usage + 1, gmt_modified = ? WHERE tenant_id = ? AND usage < ? AND quota = 0",
+                CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.TENANT_ID),
+                        context.getWhereParameter(FieldConstant.USAGE)));
+    }
+
+    @Override
+    public MapperResult incrementUsageWithQuotaLimit(MapperContext context) {
+        return new MapperResult(
+                "UPDATE tenant_capacity SET usage = usage + 1, gmt_modified = ? WHERE tenant_id = ? AND usage < quota AND quota != 0",
+                CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.TENANT_ID)));
+    }
+
+    @Override
+    public MapperResult incrementUsage(MapperContext context) {
+        return new MapperResult("UPDATE tenant_capacity SET usage = usage + 1, gmt_modified = ? WHERE tenant_id = ?",
+                CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.TENANT_ID)));
+    }
+
+    @Override
+    public MapperResult decrementUsage(MapperContext context) {
+        return new MapperResult(
+                "UPDATE tenant_capacity SET usage = usage - 1, gmt_modified = ? WHERE tenant_id = ? AND usage > 0",
+                CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.TENANT_ID)));
+    }
+
+    @Override
+    public MapperResult correctUsage(MapperContext context) {
+        return new MapperResult(
+                "UPDATE tenant_capacity SET usage = (SELECT count(*) FROM config_info WHERE tenant_id = ?), "
+                        + "gmt_modified = ? WHERE tenant_id = ?",
+                CollectionUtils.list(context.getWhereParameter(FieldConstant.TENANT_ID),
+                        context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
+                        context.getWhereParameter(FieldConstant.TENANT_ID)));
+    }
+
+    @Override
+    public MapperResult insertTenantCapacity(MapperContext context) {
+        List<Object> paramList = new ArrayList<>();
+        paramList.add(context.getUpdateParameter(FieldConstant.TENANT_ID));
+        paramList.add(context.getUpdateParameter(FieldConstant.QUOTA));
+        paramList.add(context.getUpdateParameter(FieldConstant.MAX_SIZE));
+        paramList.add(context.getUpdateParameter(FieldConstant.MAX_AGGR_COUNT));
+        paramList.add(context.getUpdateParameter(FieldConstant.MAX_AGGR_SIZE));
+        paramList.add(context.getUpdateParameter(FieldConstant.GMT_CREATE));
+        paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
+        paramList.add(context.getWhereParameter(FieldConstant.TENANT_ID));
+
+        return new MapperResult(
+                "INSERT INTO tenant_capacity (tenant_id, quota, usage, max_size, max_aggr_count, max_aggr_size, "
+                        + "gmt_create, gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE tenant_id=?",
+                paramList);
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/TenantInfoMapperByOracle.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/TenantInfoMapperByOracle.java
@@ -1,0 +1,15 @@
+package com.alibaba.nacos.plugin.datasource.impl.oracle;
+
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.TenantInfoMapper;
+
+/**
+ * Oracle implementation of TenantInfoMapper.
+ */
+public class TenantInfoMapperByOracle extends AbstractMapperByOracle implements TenantInfoMapper {
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.ORACLE;
+    }
+}

--- a/plugin/datasource/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.datasource.mapper.Mapper
+++ b/plugin/datasource/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.datasource.mapper.Mapper
@@ -35,3 +35,14 @@ com.alibaba.nacos.plugin.datasource.impl.derby.TenantInfoMapperByDerby
 com.alibaba.nacos.plugin.datasource.impl.derby.TenantCapacityMapperByDerby
 com.alibaba.nacos.plugin.datasource.impl.derby.GroupCapacityMapperByDerby
 com.alibaba.nacos.plugin.datasource.impl.derby.ConfigMigrateMapperByDerby
+
+com.alibaba.nacos.plugin.datasource.impl.oracle.ConfigInfoBetaMapperByOracle
+com.alibaba.nacos.plugin.datasource.impl.oracle.ConfigInfoMapperByOracle
+com.alibaba.nacos.plugin.datasource.impl.oracle.ConfigInfoTagMapperByOracle
+com.alibaba.nacos.plugin.datasource.impl.oracle.ConfigInfoGrayMapperByOracle
+com.alibaba.nacos.plugin.datasource.impl.oracle.ConfigTagsRelationMapperByOracle
+com.alibaba.nacos.plugin.datasource.impl.oracle.HistoryConfigInfoMapperByOracle
+com.alibaba.nacos.plugin.datasource.impl.oracle.TenantInfoMapperByOracle
+com.alibaba.nacos.plugin.datasource.impl.oracle.TenantCapacityMapperByOracle
+com.alibaba.nacos.plugin.datasource.impl.oracle.GroupCapacityMapperByOracle
+com.alibaba.nacos.plugin.datasource.impl.oracle.ConfigMigrateMapperByOracle

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
@@ -45,7 +45,7 @@ class MapperManagerTest {
         Field declaredField = mapperManagerClass.getDeclaredField("MAPPER_SPI_MAP");
         declaredField.setAccessible(true);
         Map<String, Map<String, Mapper>> map = (Map<String, Map<String, Mapper>>) declaredField.get(instance);
-        assertEquals(2, map.size());
+        assertEquals(3, map.size());
     }
     
     @Test


### PR DESCRIPTION
## Summary
- add `ORACLE` constant and trusted functions
- implement Oracle-specific mappers and service provider entries
- allow detecting Oracle driver and test query
- update mapper manager test for the new datasource

## Testing
- `./mvnw -q -pl plugin/datasource test` *(fails: Failed to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68650919ba708324ad924f7ba667ae31